### PR TITLE
Refactored code to rely on native libraries and fixed minor error

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ systems, try `sudo apt install adb`.
 - Install `expect`. On macOS, run `brew install expect`. On Debian-based
   systems, run `sudo apt install expect`.
 
+- Install `libimobiledevice`. On macOS, run `brew install libimobiledevice`.
+
+- Install `ideviceinstaller`. On macOS, run `brew install ideviceinstaller`.
+
+- Install `ifuse` (via https://github.com/libimobiledevice/ifuse). On macOS, run:
+`brew install autoconf`
+`brew install automake`
+`brew install libtool`
+`cd ifuse`
+`./autogen.sh`
+`make`
+`sudo make install`
+
 - **Linux/WSL2 only:** If you are running Linux or WSL2, install
    [patchelf](https://nixos.org/patchelf.html) (on Debian-based systems, this
 can be done like `sudo apt install patchelf`) and then run

--- a/config.py
+++ b/config.py
@@ -78,7 +78,8 @@ PLATFORM = ('darwin' if platform == 'darwin'
 ADB_PATH = shlex.quote(str(ANDROID_HOME / ('adb-' + PLATFORM)))
 #ADB_PATH = 'adb'
 
-LIBIMOBILEDEVICE_PATH = shlex.quote(str(STATIC_DATA / ("libimobiledevice-" + PLATFORM)))
+#LIBIMOBILEDEVICE_PATH = shlex.quote(str(STATIC_DATA / ("libimobiledevice-" + PLATFORM)))
+LIBIMOBILEDEVICE_PATH = ''
 # MOBILEDEVICE_PATH = 'mobiledevice'
 # MOBILEDEVICE_PATH = os.path.join(THISDIR, "mdf")  #'python2 -m MobileDevice'
 MOBILEDEVICE_PATH = shlex.quote(str(STATIC_DATA / ("ios-deploy-" + PLATFORM)))

--- a/scripts/ios_dump.sh
+++ b/scripts/ios_dump.sh
@@ -10,23 +10,12 @@ elif [[ "$unamestr" == 'FreeBSD' ]]; then
    platform='freebsd'
 fi
 
-#if [[ $platform == 'darwin' ]]; then
-#    export PATH=${DIR}/../static_data/libimobiledevice-darwin/:$PATH
-#    libi="${DIR}/../static_data/libimobiledevice-darwin"
-#elif [[ $platform == 'linux' ]]; then
-#    export PATH=${DIR}/../static_data/libimobiledevice-linux/:$PATH
-#    libi="${DIR}/../static_data/libimobiledevice-linux"
-#fi
 echo "$platform" "$adb"
-#echo $(which idevice_id)
 
-#serial=$("${libi}/idevice_id" -l 2>&1 | tail -n 1)
 serial=$(idevice_id -l 2>&1 | tail -n 1)
 mkdir -p phone_dumps/"$1"_ios
 cd phone_dumps/"$1"_ios
 # gets all of the details about each app (basically what ios_deploy does but with extra fields)
-# ideviceinstaller -u "'""$serial"'"' -l -o xml -o list_all > $2
-#"${libi}/ideviceinstaller" -l -o xml -o list_all > $2
 ideviceinstaller -u "$serial" -l -o xml -o list_all > $2
 
 # get around bug in Python 3 that doesn't recognize utf-8 encodings.
@@ -37,8 +26,6 @@ sed -i -e 's/<\/data>/<\/string>/g' $2
 # plutil -convert json $2 
 
 # gets OS version, serial, etc. -x for xml. Raw is easy to parse, too.
-#ideviceinfo -u "$serial" -x > $3
-#"${libi}/ideviceinfo" -x > $3
 ideviceinfo -u "$serial" -x > $3
 
 sed -i -e 's/<data>/<string>/g' $3
@@ -66,12 +53,9 @@ sed -i -e 's/<\/data>/<\/string>/g' $3
 # if fails (so in that case not jailbroken -- or 'not sure' for false negative).
 rm -rf /tmp/phonescanmnt
 mkdir -p /tmp/phonescanmnt
-#"${libi}/ifuse" --root /tmp/phonescanmnt &> $4
-#"${libi}/ifuse" -u "$serial" --root /tmp/phonescanmnt &> $4
 ifuse -u "$serial" --root /tmp/phonescanmnt &> $4
 
 #lsof -ti tcp:2222 | xargs kill
-#"${libi}/iproxy" 2222 22 & 
 iproxy 2222 22 & "${DIR}/ios_ssh_expect.sh" localhost
 echo $? > $5
 cd ..

--- a/scripts/ios_dump.sh
+++ b/scripts/ios_dump.sh
@@ -10,22 +10,24 @@ elif [[ "$unamestr" == 'FreeBSD' ]]; then
    platform='freebsd'
 fi
 
-if [[ $platform == 'darwin' ]]; then
-    export PATH=${DIR}/../static_data/libimobiledevice-darwin/:$PATH
-    libi="${DIR}/../static_data/libimobiledevice-darwin"
-elif [[ $platform == 'linux' ]]; then
-    export PATH=${DIR}/../static_data/libimobiledevice-linux/:$PATH
-    libi="${DIR}/../static_data/libimobiledevice-linux"
-fi
+#if [[ $platform == 'darwin' ]]; then
+#    export PATH=${DIR}/../static_data/libimobiledevice-darwin/:$PATH
+#    libi="${DIR}/../static_data/libimobiledevice-darwin"
+#elif [[ $platform == 'linux' ]]; then
+#    export PATH=${DIR}/../static_data/libimobiledevice-linux/:$PATH
+#    libi="${DIR}/../static_data/libimobiledevice-linux"
+#fi
 echo "$platform" "$adb"
 #echo $(which idevice_id)
 
-serial=$("${libi}/idevice_id" -l 2>&1 | tail -n 1)
+#serial=$("${libi}/idevice_id" -l 2>&1 | tail -n 1)
+serial=$(idevice_id -l 2>&1 | tail -n 1)
 mkdir -p phone_dumps/"$1"_ios
 cd phone_dumps/"$1"_ios
 # gets all of the details about each app (basically what ios_deploy does but with extra fields)
 # ideviceinstaller -u "'""$serial"'"' -l -o xml -o list_all > $2
-"${libi}/ideviceinstaller" -l -o xml -o list_all > $2
+#"${libi}/ideviceinstaller" -l -o xml -o list_all > $2
+ideviceinstaller -u "$serial" -l -o xml -o list_all > $2
 
 # get around bug in Python 3 that doesn't recognize utf-8 encodings.
 sed -i -e 's/<data>/<string>/g' $2
@@ -36,7 +38,8 @@ sed -i -e 's/<\/data>/<\/string>/g' $2
 
 # gets OS version, serial, etc. -x for xml. Raw is easy to parse, too.
 #ideviceinfo -u "$serial" -x > $3
-"${libi}/ideviceinfo" -x > $3
+#"${libi}/ideviceinfo" -x > $3
+ideviceinfo -u "$serial" -x > $3
 
 sed -i -e 's/<data>/<string>/g' $3
 sed -i -e 's/<\/data>/<\/string>/g' $3
@@ -63,12 +66,13 @@ sed -i -e 's/<\/data>/<\/string>/g' $3
 # if fails (so in that case not jailbroken -- or 'not sure' for false negative).
 rm -rf /tmp/phonescanmnt
 mkdir -p /tmp/phonescanmnt
-"${libi}/ifuse" --root /tmp/phonescanmnt &> $4
+#"${libi}/ifuse" --root /tmp/phonescanmnt &> $4
 #"${libi}/ifuse" -u "$serial" --root /tmp/phonescanmnt &> $4
+ifuse -u "$serial" --root /tmp/phonescanmnt &> $4
 
 #lsof -ti tcp:2222 | xargs kill
-"${libi}/iproxy" 2222 22 & 
-"${DIR}/ios_ssh_expect.sh" localhost
+#"${libi}/iproxy" 2222 22 & 
+iproxy 2222 22 & "${DIR}/ios_ssh_expect.sh" localhost
 echo $? > $5
 cd ..
 

--- a/web/view/scan.py
+++ b/web/view/scan.py
@@ -1,5 +1,6 @@
 import json
 import config
+import os
 from web import app
 from web.view.index import get_device
 from flask import render_template, request, session


### PR DESCRIPTION
Changes made: 
- Refactored code to rely on natively installed libraries rather than those packaged by isdi (in ios_scan.sh)
- Fixed error in web app (missing import statement)
- Updated readme to include install instructions for new dependencies
- Fork tested and working on iOS and Android