### PR TITLE
Update README.md with brew install step for Fuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ devices`).
 `brew install autoconf`
 `brew install automake`
 `brew install libtool`
+`brew install macfuse`
 `cd ifuse`
 `./autogen.sh`
 `make`


### PR DESCRIPTION
Added a step to install Fuse via Homebrew because macOS users who don't have Fuse installed will encounter errors during the autogen process if Fuse is missing. 