### PR TITLE
Update macOS install steps for ifuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Brew (a software package manager); finally, `brew install python` to get Python
 requirements.txt` in the base directory of this repository to get the required
 Python modules.
 
-### Miscellaneous System dependencies
+### Operating system dependencies
 - Install ADB for your operating system (via
 https://developer.android.com/studio/releases/platform-tools.html). On
 macOS, try `brew install --cask android-platform-tools`. On Debian-based
@@ -51,6 +51,7 @@ devices`).
 `brew install autoconf`
 `brew install automake`
 `brew install libtool`
+`brew install --cask macfuse`
 `cd ifuse`
 `./autogen.sh`
 `make`


### PR DESCRIPTION
Include step to install FUSE on macOS as a requirement for [ifuse](https://github.com/libimobiledevice/ifuse) installation. Will submit a PR on the ifuse repo to request macOS installation instructions.