### PR TITLE
Changed default port. Added logic to start app in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ devices`).
 - Install `expect`. On macOS, run `brew install expect`. On Debian-based
   systems, run `sudo apt install expect`.
 
-- Install `libimobiledevice`. On macOS, run `brew install libimobiledevice`.
+- Install `libimobiledevice`. On macOS, run `brew install libimobiledevice`. On Debian-based
+  systems, run `sudo apt install libimobiledevice-utils`.
 
-- Install `ideviceinstaller`. On macOS, run `brew install ideviceinstaller`.
+- Install `ideviceinstaller`. On macOS, run `brew install ideviceinstaller`.On Debian-based
+  systems, run `sudo apt install ideviceinstaller`.
 
 - Install `ifuse` (via https://github.com/libimobiledevice/ifuse). On macOS, run:
 `brew install autoconf`
@@ -58,6 +60,8 @@ devices`).
 `./autogen.sh`
 `make`
 `sudo make install`
+On Debian-based systems, run `sudo apt install ifuse`.
+
 
 - **Linux/WSL2 only:** If you are running Linux or WSL2, install
    [patchelf](https://nixos.org/patchelf.html) (on Debian-based systems, this
@@ -81,7 +85,7 @@ via:
 
 ```$ TEST=0 ./isdi```
 
-Then navigate to `http://localhost:5000` in the browser of your choice (or `http://localhost:5002` if
+Then navigate to `http://localhost:6200` in the browser of your choice (or `http://localhost:6202` if
 in test mode). You will see ISDi running as a web app. Click on `"Scan Instructions"` and follow 
 the instructions to prepare your device for the scan.
 

--- a/isdi
+++ b/isdi
@@ -9,8 +9,6 @@ from db import init_db
 from web import app, sa
 
 def open_browser():
-    if config.DEBUG:
-        return
     webbrowser.open('http://127.0.0.1:' + str(PORT), new=0, autoraise=True)
 
 if __name__ == "__main__":
@@ -29,6 +27,5 @@ if __name__ == "__main__":
     logger.setLevel(logging.ERROR)
     logger.addHandler(handler)
     PORT = 6200 if not config.TEST else 6202
-    Timer(1.25, open_browser).start()
-    app.run(host="0.0.0.0", port=PORT, debug=config.DEBUG)
-    
+    Timer(1, open_browser).start()
+    app.run(host="0.0.0.0", port=PORT, debug=config.DEBUG, use_reloader= False)

--- a/isdi
+++ b/isdi
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 import logging
 import logging.handlers as handlers
+import webbrowser
+from threading import Timer
 
 import config
 from db import init_db
 from web import app, sa
 
+def open_browser():
+    if config.DEBUG:
+        return
+    webbrowser.open('http://127.0.0.1:' + str(PORT), new=0, autoraise=True)
 
 if __name__ == "__main__":
     import sys
@@ -22,5 +28,7 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.ERROR)
     logger.addHandler(handler)
-    PORT = 5000 if not config.TEST else 5002
+    PORT = 6200 if not config.TEST else 6202
+    Timer(1.25, open_browser).start()
     app.run(host="0.0.0.0", port=PORT, debug=config.DEBUG)
+    

--- a/phone_scanner.command
+++ b/phone_scanner.command
@@ -3,4 +3,4 @@ cd /Users/rahul/phone_scanner
 mkdir -p phone_dumps data
 python3 server.py $@  2>&1 >>/tmp/scanner.log &
 sleep 2
-/usr/bin/open -a "/Applications/Google Chrome.app" 'http://localhost:5000' 2>&1 >>/tmp/chrome.log &
+/usr/bin/open -a "/Applications/Google Chrome.app" 'http://localhost:6200' 2>&1 >>/tmp/chrome.log &

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,7 +1,6 @@
 from datetime import datetime, timedelta
 from time import strftime
 import logging
-
 import config
 from flask import Flask, g, session, request
 from flask_sqlalchemy import Model, SQLAlchemy

--- a/webstatic/style.css
+++ b/webstatic/style.css
@@ -16,7 +16,7 @@ a.appid {
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(http://localhost:5000/webstatic/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2) format('woff2');
+  src: url(http://localhost:6200/webstatic/flUhRq6tzZclQEJ-Vdg-IuiaDsNc.woff2) format('woff2');
 }
 
 .material-icons {


### PR DESCRIPTION
- Updated installation steps for Ubuntu (Verified on Ubuntu 20.04). Changed port number in instructions.
- Changed port number from 5000 to 6200.
- Added logic to start browser automatically (disabled when running in DEBUG mode). It can be made to work in debug mode by simply disabling Flask's auto reloader by setting app.run(use_reloader=False) . Otherwise the browser tab is opened twice if run in debug mode.

Resolves #19 