### PR TITLE
Update cerberbus package name

### DIFF
--- a/static_data/app-flags.csv
+++ b/static_data/app-flags.csv
@@ -2505,6 +2505,7 @@ com.yottajoy.gdrive,playstore,dual-use,GDriveSync
 com.quality.droid.apps.easy_gps_locator,playstore,dual-use,Easy GPS Locator
 com.mashaapps.mobile.number.tracker,playstore,dual-use,GPS Mobile Number Location
 com.lsdroid.cerberus,playstore,spyware,Cerberus anti theft
+com.ssurebrec,playstore,spyware,Cerberus anti theft
 de.afischer.aftrack.lite,playstore,dual-use,AFTrack-Lite - GPS Tracking
 com.softians.gpstracker.mobilelocationtracer.routefinder,playstore,dual-use,Girl Friend Mobile Number Location Tracker
 de.dieterthiess.celltracker,playstore,dual-use,Cell Tracker (Unreleased)
@@ -4800,6 +4801,7 @@ com.fp.backup,playstore,spyware,FlexiSpy
 com.android.phone.dialer,playstore,spyware,FlexiSpy
 com.lsdroid.cerberuss,playstore,spyware,Cerberus
 com.lsdroid.cerberus.persona,playstore,spyware,Cerberus
+com.lsdroid.cerberus.persona2,playstore,spyware,Cerberus
 com.lsdroid.cerberus.kids,playstore,spyware,Cerberus
 com.lsdroid.cerberus.client,playstore,spyware,Cerberus
 android.helper.system,playstore,spyware,"celSpy,eyeZy,mSpy,mSpyOnline,FakeSys"


### PR DESCRIPTION
Cerberus was no longer being flagged as spyware since the name of the package has changed. I have appended the names of the new Cerberus packages (specifically Cerberus Anti-Theft and Cerberus Persona) so that it will now be flagged.