### PR TITLE
Change IOS Capabilities to use pymobiledevie3 instead of libimobile device

### DIFF
--- a/config.py
+++ b/config.py
@@ -57,8 +57,8 @@ ANDROID_PERMISSIONS_CSV = "static_data/android_permissions.csv"
 IOS_DUMPFILES = {
     "Jailbroken-FS": "ios_jailbroken.log",
     "Jailbroken-SSH": "ios_jailbreak_ssh.retcode",
-    "Apps": "ios_apps.plist",
-    "Info": "ios_info.xml",
+    "Apps": "ios_apps.json",
+    "Info": "ios_info.json",
 }
 
 TEST_APP_LIST = "static_data/android.test.apps_list"

--- a/phone_scanner/__init__.py
+++ b/phone_scanner/__init__.py
@@ -525,7 +525,7 @@ class IosScan(AppScan):
             return re.match(r"[a-f0-9]+", x) is not None
 
         # cmd = "{}idevice_id -l | tail -n 1".format(self.cli)
-        cmd = "{}pymobiledevice3 usbmux list | awk -F'\"' '/Identifier/ {{print $4}}'".format(self.cli)
+        cmd = "pymobiledevice3 usbmux list | awk -F'\"' '/Identifier/ {{print $4}}'"
         self.serialno = None
         s = catch_err(run_command(cmd), cmd=cmd, msg="")
 

--- a/phone_scanner/__init__.py
+++ b/phone_scanner/__init__.py
@@ -524,8 +524,8 @@ class IosScan(AppScan):
             """Is it looks like a serial number"""
             return re.match(r"[a-f0-9]+", x) is not None
 
-        # cmd = '{cli} --detect -t1 | tail -n 1'
-        cmd = "{}idevice_id -l | tail -n 1".format(self.cli)
+        # cmd = "{}idevice_id -l | tail -n 1".format(self.cli)
+        cmd = "{}pymobiledevice3 usbmux list | awk -F'\"' '/Identifier/ {{print $4}}'".format(self.cli)
         self.serialno = None
         s = catch_err(run_command(cmd), cmd=cmd, msg="")
 

--- a/phone_scanner/parse_dump.py
+++ b/phone_scanner/parse_dump.py
@@ -9,7 +9,7 @@ import config
 from collections import OrderedDict
 from functools import reduce
 from pathlib import Path
-from plistlib import load
+# from plistlib import load
 from typing import List, Dict
 import pandas as pd
 from rsonlite import simpleparse
@@ -463,7 +463,7 @@ class IosDump(PhoneDump):
     def load_device_info(self):
         try:
             with open(self.finfo, "rb") as data:
-                device_info = load(data)
+                device_info = json.load(data)
             return device_info
 
         except Exception as ex:
@@ -479,11 +479,14 @@ class IosDump(PhoneDump):
     def load_file(self):
         # d = pd.read_json(self.fname)[self.COLS].set_index(self.INDEX)
         try:
-            # FIXME: somehow, get the ios_apps.plist into a dataframe.
             print("fname is: {}".format(self.fname))
-            with open(self.fname, "rb") as app_data:
-                apps_plist = load(app_data)
-            d = pd.DataFrame(apps_plist)
+            apps_list = []
+            with open(self.fname, "r") as app_data:
+                apps_json = json.load(app_data)
+                for k in apps_json:
+                    apps_list.append(apps_json[k])
+
+            d = pd.DataFrame(apps_list)
             d["appId"] = d["CFBundleIdentifier"]
             return d
         except Exception as ex:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ Mako>=1.2.4
 MarkupSafe>=2.1.1
 numpy>=1.23.5
 pandas>=1.5.2
+pymobiledevice3==4.20.17
 pycodestyle>=2.10.0
 python-dateutil>=2.8.2
 python-dotenv>=0.10.3

--- a/scripts/ios_dump.sh
+++ b/scripts/ios_dump.sh
@@ -12,26 +12,29 @@ fi
 
 echo "$platform" "$adb"
 
-serial=$(idevice_id -l 2>&1 | tail -n 1)
+# serial=$(idevice_id -l 2>&1 | tail -n 1)
+serial=$(pymobiledevice3 usbmux list | awk -F'"' '/Identifier/ {print $4}')
 mkdir -p phone_dumps/"$1"_ios
 cd phone_dumps/"$1"_ios
 # gets all of the details about each app (basically what ios_deploy does but with extra fields)
-ideviceinstaller -u "$serial" -l -o xml -o list_all > "$2"
+# ideviceinstaller -u "$serial" -l -o xml -o list_all > "$2"
+pymobiledevice3 apps list > "$2"
 
 # get around bug in Python 3 that doesn't recognize utf-8 encodings.
 # sed -i -e 's/<data>/<string>/g' $2
 # sed -i -e 's/<\/data>/<\/string>/g' $2
 
 # maybe for macOS...
-# plutil -convert json $2 
+# plutil -convert json $2
 
 # gets OS version, serial, etc. -x for xml. Raw is easy to parse, too.
-ideviceinfo -u "$serial" -x > $3
+# ideviceinfo -u "$serial" -x > $3
+pymobiledevice3 lockdown info > "$3"
 
 # sed -i -e 's/<data>/<string>/g' $3
 # sed -i -e 's/<\/data>/<\/string>/g' $3
 
-# remove identifying info (delete file after saving 
+# remove identifying info (delete file after saving
 # relevant bits of scan in server.py, actually)
 #sed -i -e '/<\key>DeviceName<\/key>/,+1d' $3
 #sed -i -e '/<\key>MobileEquipmentIdentifier<\/key>/,+1d' $3
@@ -45,7 +48,7 @@ ideviceinfo -u "$serial" -x > $3
 # delete this after hashing when session ends.
 #sed -i -e '/<\key>InternationalMobileEquipmentIdentity<\/key>/,+1d' $3
 
-# try to check for jailbroken by mounting the entire filesystem. 
+# try to check for jailbroken by mounting the entire filesystem.
 # Gets output:
 # "Failed to start AFC service 'com.apple.afc2' on the device.
 # This service enables access to the root filesystem of your device.


### PR DESCRIPTION
Rather than use libimobiledevice which has some known compatibility issues with newer versions of IOS, pymobiledevice3 has much better support for devices with >IOS 17. Furthermore, libimobiledevice lacks support for Windows, which pymobiledevice3 supports (though I have not tested it in Windows).