### PR TITLE
add device owner privilege detection for android

### DIFF
--- a/phone_scanner/__init__.py
+++ b/phone_scanner/__init__.py
@@ -141,6 +141,34 @@ class AppScan(object):
             offstore_apps=self.get_offstore_apps(serialno, from_dump=from_dump),
             system_apps=self.get_system_apps(serialno, from_dump=from_dump),
         )
+
+        # Device Owner apps detection
+        if self.device_type == "android":
+            device_owner_apps = set()
+
+            if not from_dump:
+                device_owner_apps = self.get_device_owner_apps(serialno)
+            elif getattr(self, "dump_d", None):
+                def _walk(node):
+                    if isinstance(node, dict):
+                        for k, v in node.items():
+                            if "DeviceOwner" in k and "admin=" in k:
+                                m = re.search(r"admin=([a-zA-Z0-9_.]+)/", k)
+                                if m:
+                                    device_owner_apps.add(m.group(1))
+                            else:
+                                _walk(v)
+                    elif isinstance(node, list):
+                        for item in node:
+                            if isinstance(item, str):
+                                if "DeviceOwner" in item and "admin=" in item:
+                                    m = re.search(r"admin=([a-zA-Z0-9_.]+)/", item)
+                                    if m:
+                                        device_owner_apps.add(m.group(1))
+                            else:
+                                _walk(item)
+                _walk(self.dump_d.df.get("device_owner", {}))
+
         r["title"] = r.title.fillna("")
         if self.device_type == "android":
             td = pd.read_sql(
@@ -302,6 +330,22 @@ class AndroidScan(AppScan):
             else:
                 print(">>>>>> ERROR: {}".format(line), file=sys.stderr)
         return offstore
+
+    def get_device_owner_apps(self, serialno: str) -> set:
+        cmd = "{cli} -s {serial} shell dpm list-owners"
+        s = catch_err(
+            run_command(cmd, cli=self.cli, serial=serialno),
+            cmd=cmd
+        )
+        device_owner_apps = set()
+        if not s:
+            return device_owner_apps
+        for line in s.splitlines():
+            if "DeviceOwner" in line and "admin=" in line:
+                m = re.search(r"admin=([a-zA-Z0-9_.]+)/", line)
+                if m:
+                    device_owner_apps.add(m.group(1))
+        return device_owner_apps
 
     def devices(self):
         # FIXME: check for errors related to err in runcmd.py.

--- a/phone_scanner/blocklist.py
+++ b/phone_scanner/blocklist.py
@@ -78,6 +78,7 @@ def score(flags):
         "regex-spy": 0.3,
         "odds-ratio": 0.2,
         "system-app": -0.1,
+        "device-owner": 1.0,
     }
     return sum(map(lambda x: weight.get(x, 0.0), flags))
 
@@ -97,7 +98,7 @@ def flag_str(flags):
     def _add_class(flag):
         return (
             "primary"
-            if "spyware" in flag
+            if "spyware" in flag or flag == "device-owner"
             else "warning" if "dual-use" in flag else "info" if "spy" in flag else ""
         )
 
@@ -113,6 +114,7 @@ def flag_str(flags):
             "offstore-app": "This app is installed outside Play Store. It might be a preinstalled app too.",
             "dual-use": "This app has a legitimate usecase, but can be harmful in certain situations.",
             "system-app": "This app came preinstalled with the device.",
+            "device-owner": "This app has device owner privilege, allowing it to have almost full control over the device.",
         }.get(flag.lower(), flag)
 
     # If spyware <span class='text-danger'>{}</span>


### PR DESCRIPTION
Addresses issue #77 

Modifications:
- `phone_scanner/__init__.py`: Added `get_device_owner_apps()` to `AndroidScan`, which queries `adb shell dpm list-owners` directly from the device. Updated `find_spyapps()` to apply the `device-owner` flag
- `phone_scanner/blocklist.py`: Added `device-owner` to the scoring weights (1.0), severity class (primary), and flag info