### PR TITLE
fix device owner and other stuff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pymobiledevice3>=4.0",
     "click>=8.0",
     "pyyaml>=6.0",
+    "rsonlite>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/src/isdi/scanner/__init__.py
+++ b/src/isdi/scanner/__init__.py
@@ -10,8 +10,10 @@ Phone scanner module - handles Android and iOS device scanning.
 from math import perm
 import os
 import json
+import re
 import shlex
 import sqlite3
+import subprocess
 import logging
 from pathlib import Path
 from datetime import datetime
@@ -95,13 +97,16 @@ class AppScanner:
 
     def _load_dump(self, serialno: str) -> Optional[parse_dump.PhoneDump]:
         """Load device dump from file, creating it if needed."""
-        if isinstance(self.ddump, parse_dump.PhoneDump):
-            return self.ddump
-
         dumpf = self.dump_path(serialno)
-        if not os.path.exists(dumpf):
+
+        # Re-dump if file is missing or suspiciously small (a header-only empty dump is ~600B)
+        if not os.path.exists(dumpf) or os.path.getsize(dumpf) < 5000:
+            self.ddump = None
             if not self._dump_phone(serialno):
                 return None
+
+        if isinstance(self.ddump, parse_dump.PhoneDump):
+            return self.ddump
 
         try:
             if self.device_type == "android":
@@ -118,6 +123,12 @@ class AppScanner:
         dumpf = self.dump_path(serial)
         os.makedirs(os.path.dirname(dumpf), exist_ok=True)
 
+        # Delete stale JSON cache so load_file re-parses the fresh txt dump
+        json_cache = dumpf.rsplit(".", 1)[0] + ".json"
+        if os.path.exists(json_cache):
+            os.unlink(json_cache)
+        self.ddump = None
+
         # Resolve script path
         script_path = cfg.SCRIPT_DIR / f"{self.device_type}_scan.sh"
         if not script_path.exists():
@@ -129,9 +140,9 @@ class AppScanner:
         # Run script: bash script.sh <serial> <output_file>
         p = run_command(
             "bash {script} {ser} {dump_file}",
-            script=str(script_path),
-            ser=serial,
-            dump_file=dumpf,
+            script=shlex.quote(str(script_path)),
+            ser=shlex.quote(serial),
+            dump_file=shlex.quote(dumpf),
             nowait=False,
         )
 
@@ -278,6 +289,21 @@ class AppScanner:
                 "html_flags": html_flags,
             }
 
+        # Device owner detection (Android only — queries dpm list-owners on the live device)
+        if self.device_type == "android" and hasattr(self, "get_device_owner_apps"):
+            for appid in self.get_device_owner_apps(serialno):
+                if appid in result:
+                    flags = result[appid]["flags"]
+                    if "device-owner" not in flags:
+                        flags = flags + ["device-owner"]
+                        result[appid] = {
+                            **result[appid],
+                            "flags": flags,
+                            "score": blocklist.score(flags),
+                            "class_": blocklist.assign_class(flags),
+                            "html_flags": blocklist.flag_str(flags),
+                        }
+
         # Sort by risk score descending, then by appId ascending
         sorted_apps = sorted(result.items(), key=lambda x: (-x[1]["score"], x[0]))
 
@@ -309,6 +335,84 @@ class AndroidScanner(AppScanner):
         if p.returncode != 0:
             logging.error(f"ADB setup failed with returncode {p.returncode}")
 
+    def _dump_phone(self, serial: str) -> bool:
+        """Dump Android device info by running adb commands directly.
+
+        Runs adb via self.cli (cfg.ADB_PATH) so the same binary Python uses
+        is used here, avoiding bash-environment adb detection issues on WSL.
+        """
+        dumpf = self.dump_path(serial)
+        os.makedirs(os.path.dirname(dumpf), exist_ok=True)
+
+        json_cache = dumpf.rsplit(".", 1)[0] + ".json"
+        if os.path.exists(json_cache):
+            os.unlink(json_cache)
+        self.ddump = None
+
+        logging.info(f"Dumping android device {serial}...")
+
+        services = [
+            "package", "location", "media.camera", "netpolicy", "mount",
+            "cpuinfo", "dbinfo", "meminfo", "procstats", "batterystats",
+            "netstats detail", "usagestats", "activity", "appops",
+        ]
+        _email_re = re.compile(
+            r"(\s*)[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,4}\b"
+        )
+
+        def _run(*args, timeout=120) -> str:
+            try:
+                r = subprocess.run(
+                    [self.cli, "-s", serial, *args],
+                    capture_output=True, text=True,
+                    timeout=timeout, errors="replace",
+                )
+                return r.stdout
+            except subprocess.TimeoutExpired:
+                logging.warning(f"adb timeout: {args}")
+                return ""
+
+        try:
+            with open(dumpf, "w", encoding="utf-8", errors="replace") as f:
+                for svc in services:
+                    f.write(f"\nDUMP OF SERVICE {svc}\n")
+                    out = _email_re.sub(r"\1<email>", _run("shell", "dumpsys", *svc.split()))
+                    f.write(out)
+
+                f.write("\nDUMP OF SERVICE net_stats\n")
+                f.write(_run("shell", "cat", "/proc/net/xt_qtaguid/stats", timeout=30).replace(" ", ","))
+
+                for ns in ("secure", "system", "global"):
+                    f.write(f"\nDUMP OF SETTINGS {ns}\n")
+                    f.write(_run("shell", "settings", "list", ns, timeout=30))
+
+            size = os.path.getsize(dumpf)
+            if size < 5000:
+                logging.error(
+                    f"Android dump too small ({size} bytes) — "
+                    f"{self.cli} may not be reaching device {serial}"
+                )
+                return False
+            logging.info(f"Dump completed: {dumpf} ({size} bytes)")
+            return True
+        except Exception as e:
+            logging.error(f"Android dump failed: {e}")
+            return False
+
+    def get_device_owner_apps(self, serialno: str) -> set:
+        """Return package names that hold device owner privilege on the device."""
+        cmd = "{cli} -s {serial} shell dpm list-owners"
+        s = catch_err(run_command(cmd, cli=self.cli, serial=serialno), cmd=cmd)
+        device_owner_apps = set()
+        if not s:
+            return device_owner_apps
+        for line in s.splitlines():
+            if "DeviceOwner" in line and "admin=" in line:
+                m = re.search(r"admin=([a-zA-Z0-9_.]+)/", line)
+                if m:
+                    device_owner_apps.add(m.group(1))
+        return device_owner_apps
+
     def devices(self) -> List[str]:
         """Get list of connected Android devices."""
         cmd = "{cli} devices | tail -n +2"
@@ -324,6 +428,13 @@ class AndroidScanner(AppScanner):
 
     def get_apps(self, serialno: str) -> List[str]:
         """Get installed apps from dump."""
+        # Always start with a fresh dump — delete old txt so _load_dump re-runs _dump_phone.
+        # This also ensures the stale JSON cache (cleaned up inside _dump_phone) is never reused.
+        dumpf = self.dump_path(serialno)
+        if os.path.exists(dumpf):
+            os.unlink(dumpf)
+        self.ddump = None
+
         result = self._load_dump(serialno)
         if not result or not self.ddump:
             logging.error(f"Cannot load dump for {serialno}")

--- a/src/isdi/scanner/parse_dump.py
+++ b/src/isdi/scanner/parse_dump.py
@@ -439,8 +439,8 @@ class AndroidDump(PhoneDump):
         if self.apps:
             return self.apps
         d = self.df
-        if not d or not d["package"]:
-            logging.error(f"'package' is not a key in self.df, where keys = {list(d.keys())}")
+        if not d or not d.get("package"):
+            logging.error(f"'package' section is empty or missing from dump; keys = {list(d.keys())}")
             return {}
         app_d = d["package"][0]["Packages"]
         # get_all_leaves(match_keys(d, "^package$//^Packages//^Package .*"))

--- a/src/isdi/web/view/scan.py
+++ b/src/isdi/web/view/scan.py
@@ -185,7 +185,7 @@ def scan():
                 "The scanning failed. This could be due to many reasons. Try"
                 " rerunning the scan from the beginning. If the problem persists,"
                 " please report it in the file. <code>report_failed.md</code> in the<code>"
-                "phone_scanner/</code> directory. Checn the phone manually. Sorry for"
+                "phone_scanner/</code> directory. Check the phone manually. Sorry for"
                 " the inconvenience."
             )
             template_d["error"] = error


### PR DESCRIPTION
changes:
- typo in web view: "Checn" -> "Check"
- add rsonlite in pyproject.toml
- improve src/isdi/scanner/init.py 
	- issues:
		1. fail when path name contains space
		2. a failed scan produces empty dump -> cached as xxx_android.json, then every subsequent scan uses this empty cache
		3. on windows + wsl2 environment, it will default to linux `adb` which can not detect usb devices
		4. device owner detection missing after refactor
	- changes:
		- issue 1
			- use shlex to quote around pathname
		- issue 2
			- `AndroidScanner.get_apps` now deletes stale dump before live scan so `_load_dump` always calls `_dump_phone`
			- `_dump_phone` deletes stale JSON cache before running the script and resets `self.ddump = None`
			- `_load_dump` size check for empty dumps (< 5 KB)
		- issue 3
			- add `_dump_phone` to init.py, runs adb in python via `subprocess.run([self.cli, "-s", serial, ...])` where self.cli is adb.exe (on windows)
		- issue 4
			- added device owner detection back to init.py
- improve src/isdi/scanner/parse_dump.py error message 